### PR TITLE
HeaderLine Verifier

### DIFF
--- a/include/httpparser.h
+++ b/include/httpparser.h
@@ -47,9 +47,9 @@ class HTTPParser : public QObject {
 
         // Private aux methods for parsing
         HeaderBodyPair splitRequest(char *, size_t);
-        bool parseCommandLine(QString);
-        bool parseAnswerLine(QString);
-        bool parseHeaderLine(QString);
+        bool parseCL(QString);
+        bool parseHL(QString);
+        bool parseAL(QString);
         bool parse(char *, ssize_t);
 
     public:
@@ -76,6 +76,21 @@ class HTTPParser : public QObject {
 
         // Converts parsed HTTP headers to QString
         QString headerToQstring();
+
+        // Parse a header line
+        bool parseHeaderLine(QString, QString *, QString *);
+
+        // Parse a command line
+        bool parseCommandLine(QString, QString *, QString *, QString *);
+
+        // Parse an answer line
+        bool parseAnswerLine(QString, QString *, QString *, QString *);
+
+        // Verifies if a header line from REQUEST is valid
+        inline bool validRequestHeaderLine(QString);
+
+        // Verifies if a header line from ANSWER is valid
+        inline bool validAnswerHeaderLine(QString);
 
     signals:
         void logMessage(QString);

--- a/include/spider.h
+++ b/include/spider.h
@@ -39,7 +39,7 @@ class Spider : public QObject {
     QString getAbsoluteLink(QString, QString);
     QString getURL(QString);
     QString getHost(QString);
-    SpiderTree buildSpiderTree(QString, int, QStringList *);
+    SpiderTree buildSpiderTree(QString, QString, int, QStringList *);
 
     public:
         Spider();


### PR DESCRIPTION
Added methods that verify if headerline of a request or response is valid
Fixed regexp to allow host with 'http://...' on spider